### PR TITLE
Migrating slurm hyperpod recipes content from ws

### DIFF
--- a/website/docs/03-hyperpod-recipes/eks-hyperpod-recipes/hyperpod-recipes.md
+++ b/website/docs/03-hyperpod-recipes/eks-hyperpod-recipes/hyperpod-recipes.md
@@ -1,5 +1,5 @@
 ---
-title: Amazon Sagemaker Hyperpod Recipes
+title: Setup and Launch training - EKS
 sidebar_position: 1
 ---
 # Install and use the Hyperpod CLI

--- a/website/docs/03-hyperpod-recipes/index.en.md
+++ b/website/docs/03-hyperpod-recipes/index.en.md
@@ -1,5 +1,5 @@
 ---
-title: "SageMaker HyperPod Slurm recipes (p5/trn)"
+title: "SageMaker HyperPod Recipes Overview"
 sidebar_position: 1
 weight: 110
 ---

--- a/website/docs/03-hyperpod-recipes/slurm-hyperpod-recipes/setup-and-train.md
+++ b/website/docs/03-hyperpod-recipes/slurm-hyperpod-recipes/setup-and-train.md
@@ -1,5 +1,5 @@
 ---
-title: "Setup and Launch training"
+title: "Setup and Launch training - Slurm"
 sidebar_position: 2
 weight: 71
 ---


### PR DESCRIPTION
### What does this PR do?

Migrated content for slurm hyperpod recipes from workshop studios.

<!-- A brief description of the change being made with this pull request. -->
Added two new files with slurm hyperpod recipes.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` section for this feature
- [x] Mandatory for ANY PR. I have tested a build of my PR with:

``` bash
cd website
rm -rf .docusaurus/ build/
npm ci 
npm run build
```
- [x] Mandatory for ANY PR. I have rendered my PR agree it looks as it's supposed to, using `npm start`. 

### For Moderators

- [x] E2E Tested and rendered successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Rendering, build and run tested successfully for these changes. 