### PR TITLE
removed "sudo" from step 6. We don't need "sudo" during enroot import…

### DIFF
--- a/website/docs/02-slurm-blueprints/training/megatron-lm/megatron-lm-readme.md
+++ b/website/docs/02-slurm-blueprints/training/megatron-lm/megatron-lm-readme.md
@@ -87,7 +87,7 @@ All next steps will be executed on the compute node.
 6. Create the squash file with the command below.
 
    ```bash
-   sudo enroot import -o megatron-training.sqsh  dockerd://megatron-training:latest
+   enroot import -o megatron-training.sqsh  dockerd://megatron-training:latest
    ```
 
    The file will be stored in the current directory (if left as default). The output should look as below.


### PR DESCRIPTION
…. That's also consistent with the example screenshot below.

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-sagemaker-hyperpod/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. 
- [ ] Yes, I have added a example to support my blueprint PR.
- [ ] Yes, I have updated the `website/docs` section for this feature.

### For Moderators

- [ ] E2E Test successfully complete before merge?
- [ ] I ran the proper security checks explained on the ML Frameworks wiki

### Additional Notes

<!-- Anything else we should know when reviewing? -->

