### PR TITLE
included hyperpod api to reboot/replace instance

### DIFF
--- a/website/docs/06-validation-and-testing/resiliency/eks-resiliency.md
+++ b/website/docs/06-validation-and-testing/resiliency/eks-resiliency.md
@@ -146,4 +146,4 @@ Once a node becomes available the pod that is in pending should get scheduled an
 
 ## Alternative: Manual Node Operations
 
-If you prefer to manually reboot or replace nodes instead of injecting errors, you can use the HyperPod APIs or kubectl commands. For detailed instructions on manual node replacement and reboot procedures, see the [HyperPod CLI Commands Reference](/docs/08-Tips/hyperpod-cli-commands.md).
+If you prefer to manually reboot or replace nodes instead of injecting errors, you can use the HyperPod APIs or kubectl commands. For detailed instructions on manual node replacement and reboot procedures, see the [HyperPod CLI Commands Reference](/docs/Tips/Common/hyperpod-cli-commands).

--- a/website/docs/06-validation-and-testing/resiliency/slurm-resiliency.md
+++ b/website/docs/06-validation-and-testing/resiliency/slurm-resiliency.md
@@ -222,7 +222,7 @@ The job should automatically resume once the replacement node is available and h
 
 ## Alternative: Manual Node Operations
 
-If you prefer to manually reboot or replace nodes instead of injecting errors, you can use the HyperPod APIs or Slurm commands. For detailed instructions on manual node replacement and reboot procedures, see the [HyperPod CLI Commands Reference](/docs/08-Tips/hyperpod-cli-commands.md).
+If you prefer to manually reboot or replace nodes instead of injecting errors, you can use the HyperPod APIs or Slurm commands. For detailed instructions on manual node replacement and reboot procedures, see the [HyperPod CLI Commands Reference](/docs/Tips/Common/hyperpod-cli-commands).
 
 <br/>
 


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-sagemaker-hyperpod/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

Updated resiliency section to use to use batch-replace and batch-reboot instead of labels. Labelling nodes for replace/reboot does not work for Karpenter managed nodes. API is common interface that abstracts these differences + orchestrator level as well. 

API documentation here: https://aws.amazon.com/about-aws/whats-new/2025/11/amazon-sagemaker-hyperpod-programmatic-node-reboot-replacement/


### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. 
- [ ] Yes, I have added a example to support my blueprint PR.
- [x] Yes, I have updated the `website/docs` section for this feature.

### For Moderators

- [x] E2E Test successfully complete before merge?
- [x] I ran the proper security checks explained on the ML Frameworks wiki

### Additional Notes

<!-- Anything else we should know when reviewing? -->

