### PR TITLE
Introducing FSDP2 in documentation

### DIFF
--- a/website/docs/00-eks-orchestration/training-and-fine-tuning/fsdp/fully-sharded-data-parallel.md
+++ b/website/docs/00-eks-orchestration/training-and-fine-tuning/fsdp/fully-sharded-data-parallel.md
@@ -14,7 +14,6 @@ FSDP2 introduces several improvements over FSDP1:
 - **Simplified API**: `fully_shard` function instead of `FullyShardedDataParallel` class wrapper
 - **Improved checkpointing**: Communication-free sharded state dicts using DTensor APIs
 - **Meta device initialization**: Cleaner initialization flow with explicit device placement
-- **Elastic training support**: Built-in support for dynamic node scaling 
 
 ## Prerequisites
 
@@ -367,8 +366,6 @@ model.to_empty(device=torch.device("cuda"))
 **4. DTensor Parameters**
 All model parameters are now DTensor with Shard(0) placement, enabling:
 - Seamless optimizer integration
-- Communication-free sharded checkpoints
-- Easier parameter manipulation
 
 **5. Elastic Training Support**
 The template now supports elastic training with dynamic node scaling:
@@ -948,21 +945,6 @@ hyperpod list-jobs -n kubeflow
 }
 ```
 
-
-## Migration from FSDP1 to FSDP2
-
-### Code Changes
-- Replace `FullyShardedDataParallel` with `fully_shard` function
-- Use meta device initialization for all ranks
-- Update to `MixedPrecisionPolicy` and `CPUOffloadPolicy`
-- Migrate checkpointing to DTensor state dict APIs (`get_model_state_dict`, `set_model_state_dict`)
-- Use `torch.nn.utils.clip_grad_norm_` instead of `model.clip_grad_norm_`
-
-### Configuration Changes
-- Add FSx PersistentVolumeClaim for checkpoint storage
-- Update PyTorch version to 2.6.0 or later
-
-For detailed migration instructions, refer to the training code in the repository.
 
 ## Additional Resources
 

--- a/website/docs/00-eks-orchestration/training-and-fine-tuning/fsdp/fully-sharded-data-parallel.md
+++ b/website/docs/00-eks-orchestration/training-and-fine-tuning/fsdp/fully-sharded-data-parallel.md
@@ -1,10 +1,20 @@
 ---
-title: Fully Sharded Data Parallelism (FSDP)
+title: Fully Sharded Data Parallelism (FSDP2)
 sidebar_position: 1
 ---
-# Get Started Training Llama 2 with PyTorch FSDP in 5 Minutes
+# Get Started Training Llama 2 with PyTorch FSDP2 in 5 Minutes
 
-This example showcases an easy way to get started with multi node [FSDP](https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html) training on Amazon EKS on SageMaker HyperPod. It is designed to be as simple as possible, requires no data preparation, and uses a docker image. 
+This example showcases an easy way to get started with multi node [FSDP2](https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html) training on Amazon EKS on SageMaker HyperPod. FSDP2 is the next generation of PyTorch's Fully Sharded Data Parallel, offering improved memory management, DTensor integration, and a cleaner API.
+
+## What's New in FSDP2
+
+FSDP2 introduces several improvements over FSDP1:
+- **DTensor representation**: Parameters are represented as DTensor with Shard(0) placement for easier manipulation
+- **Better memory management**: Lower and deterministic GPU memory without `recordStream` and no CPU synchronization
+- **Simplified API**: `fully_shard` function instead of `FullyShardedDataParallel` class wrapper
+- **Improved checkpointing**: Communication-free sharded state dicts using DTensor APIs
+- **Meta device initialization**: Cleaner initialization flow with explicit device placement
+- **Elastic training support**: Built-in support for dynamic node scaling 
 
 ## Prerequisites
 
@@ -103,16 +113,32 @@ export REGISTRY=${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com/
 
 Build the container image:
 
+### For EKS (Base target)
+
 If you are on a Mac, use `buildx` to target `linux/amd64` architecture: 
 
     ```bash 
-    docker buildx build --platform linux/amd64 -t ${REGISTRY}fsdp:pytorch2.5.1 .
+    docker buildx build --platform linux/amd64 --target base -t ${REGISTRY}fsdp:pytorch2.6.0 .
     ```
    
     **Alternatively,** if you are running in a SageMaker Studio environment
 
     ```bash 
-    docker build $DOCKER_NETWORK -t ${REGISTRY}fsdp:pytorch2.5.1 .    
+    docker build $DOCKER_NETWORK --target base -t ${REGISTRY}fsdp:pytorch2.6.0 .    
+    ```
+
+### For HyperPod (HPTO target with elastic agent)
+
+If you are on a Mac, use `buildx` to target `linux/amd64` architecture: 
+
+    ```bash 
+    docker buildx build --platform linux/amd64 --target hpto -t ${REGISTRY}fsdp:pytorch2.6.0 .
+    ```
+   
+    **Alternatively,** if you are running in a SageMaker Studio environment
+
+    ```bash 
+    docker build $DOCKER_NETWORK --target hpto -t ${REGISTRY}fsdp:pytorch2.6.0 .    
     ```
 
 <details>
@@ -126,7 +152,7 @@ Building the image can take 5~7 minutes. If successful, you should see the follo
 
 ```
 Successfully built 123ab12345cd
-Successfully tagged 123456789012.dkr.ecr.us-west-2.amazonaws.com/fsdp:pytorch2.5.1
+Successfully tagged 123456789012.dkr.ecr.us-west-2.amazonaws.com/fsdp:pytorch2.6.0
 ```
 
 ### 1.3 Push the Image to Amazon ECR
@@ -145,7 +171,7 @@ echo "Logging in to $REGISTRY ..."
 aws ecr get-login-password | docker login --username AWS --password-stdin $REGISTRY
 
 # Push image to registry
-docker image push ${REGISTRY}fsdp:pytorch2.5.1
+docker image push ${REGISTRY}fsdp:pytorch2.6.0
 ```
 
 Pushing the image may take some time depending on your network bandwidth. If you use EC2 / CloudShell as your development machine, it will take 6~8 minutes.
@@ -203,7 +229,7 @@ Set environment variables and run `envsubst` to generate `fsdp.yaml`.
 For ml.g5.8xlarge x 8:
 
 ```bash
-export IMAGE_URI=${REGISTRY}fsdp:pytorch2.5.1
+export IMAGE_URI=${REGISTRY}fsdp:pytorch2.6.0
 export INSTANCE_TYPE=ml.g5.8xlarge
 export NUM_NODES=8
 export GPU_PER_NODE=1
@@ -308,6 +334,65 @@ To stop the current training job, use the following command:
 ```bash
 kubectl delete -f ./fsdp.yaml
 ```
+## Understanding FSDP2 Implementation
+
+### Key Differences from FSDP1
+
+The FSDP2 implementation uses several new patterns that simplify distributed training:
+
+**1. Meta Device Initialization**
+```python
+# Initialize model on meta device (no memory allocation)
+with torch.device("meta"):
+    model = AutoModelForCausalLM.from_config(model_config)
+```
+
+**2. Layer-by-Layer Sharding**
+```python
+# Apply fully_shard to transformer layers first
+for module in model.modules():
+    if isinstance(module, transformer_layer):
+        fully_shard(module, **fsdp_kwargs)
+
+# Then apply to root model
+fully_shard(model, **fsdp_kwargs)
+```
+
+**3. Explicit Device Placement**
+```python
+# Move from meta to CUDA after sharding
+model.to_empty(device=torch.device("cuda"))
+```
+
+**4. DTensor Parameters**
+All model parameters are now DTensor with Shard(0) placement, enabling:
+- Seamless optimizer integration
+- Communication-free sharded checkpoints
+- Easier parameter manipulation
+
+**5. Elastic Training Support**
+The template now supports elastic training with dynamic node scaling:
+- Uses `--nnodes=$MIN_NODES:$MAX_NODES` format
+- Jobs can start with minimum nodes and scale up
+- Automatic handling of node failures and recovery
+
+### Checkpoint Storage
+
+FSDP2 uses FSx for Lustre for distributed checkpoint storage:
+- Checkpoints are stored in `/checkpoints` directory
+- Mounted via PersistentVolumeClaim (`fsx-claim`)
+- Enables communication-free checkpoint save/load with DTensor APIs
+
+### Performance Considerations
+
+**Implicit Prefetching (Default)**
+- Works out of the box
+- CPU thread issues all-gather before each layer
+- Good for non-CPU-bound workloads
+
+**Explicit Prefetching (Advanced)**
+For better performance, you can manually control prefetching in your training code.
+
 ## Alternative: Start Training with the HyperPod CLI
 
 > **Note:**
@@ -337,10 +422,11 @@ hyperpod-i-0fe48912b03d2c22e   ml.g5.8xlarge   1     1
 Set following environment variables based on your cluster configuration.
 
 ``` bash
-export IMAGE_URI=${REGISTRY}fsdp:pytorch2.5.1
+export IMAGE_URI=${REGISTRY}fsdp:pytorch2.6.0
 export INSTANCE_TYPE=ml.g5.8xlarge
 export NUM_NODES=8
 export GPU_PER_NODE=1
+export HF_TOKEN=<Your HuggingFace Token>
 ```
 
 ### Generate a job configuration file
@@ -861,3 +947,26 @@ hyperpod list-jobs -n kubeflow
  "jobs": []
 }
 ```
+
+
+## Migration from FSDP1 to FSDP2
+
+### Code Changes
+- Replace `FullyShardedDataParallel` with `fully_shard` function
+- Use meta device initialization for all ranks
+- Update to `MixedPrecisionPolicy` and `CPUOffloadPolicy`
+- Migrate checkpointing to DTensor state dict APIs (`get_model_state_dict`, `set_model_state_dict`)
+- Use `torch.nn.utils.clip_grad_norm_` instead of `model.clip_grad_norm_`
+
+### Configuration Changes
+- Add FSx PersistentVolumeClaim for checkpoint storage
+- Update PyTorch version to 2.6.0 or later
+
+For detailed migration instructions, refer to the training code in the repository.
+
+## Additional Resources
+
+- [PyTorch FSDP2 Tutorial](https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html)
+- [DTensor Documentation](https://pytorch.org/docs/stable/distributed.tensor.html)
+- [AWS Distributed Training Examples](https://github.com/aws-samples/awsome-distributed-training)
+- [PyTorch Distributed Checkpoint](https://pytorch.org/docs/stable/distributed.checkpoint.html)

--- a/website/docs/00-eks-orchestration/training-and-fine-tuning/fsdp/fully-sharded-data-parallel.md
+++ b/website/docs/00-eks-orchestration/training-and-fine-tuning/fsdp/fully-sharded-data-parallel.md
@@ -367,12 +367,6 @@ model.to_empty(device=torch.device("cuda"))
 All model parameters are now DTensor with Shard(0) placement, enabling:
 - Seamless optimizer integration
 
-**5. Elastic Training Support**
-The template now supports elastic training with dynamic node scaling:
-- Uses `--nnodes=$MIN_NODES:$MAX_NODES` format
-- Jobs can start with minimum nodes and scale up
-- Automatic handling of node failures and recovery
-
 ### Checkpoint Storage
 
 FSDP2 uses FSx for Lustre for distributed checkpoint storage:

--- a/website/docs/00-eks-orchestration/training-and-fine-tuning/fsdp/fully-sharded-data-parallel.md
+++ b/website/docs/00-eks-orchestration/training-and-fine-tuning/fsdp/fully-sharded-data-parallel.md
@@ -9,7 +9,7 @@ This example showcases an easy way to get started with multi node [FSDP2](https:
 ## What's New in FSDP2
 
 FSDP2 introduces several improvements over FSDP1:
-- **DTensor representation**: Parameters are represented as DTensor with Shard(0) placement for easier manipulation
+- **DTensor representation**: Parameters are represented as DTensor with Shard(0) placement
 - **Better memory management**: Lower and deterministic GPU memory without `recordStream` and no CPU synchronization
 - **Simplified API**: `fully_shard` function instead of `FullyShardedDataParallel` class wrapper
 - **Improved checkpointing**: Communication-free sharded state dicts using DTensor APIs

--- a/website/docs/01-slurm-orchestration/training-and-fine-tuning/fsdp/fully-sharded-data-parallel.md
+++ b/website/docs/01-slurm-orchestration/training-and-fine-tuning/fsdp/fully-sharded-data-parallel.md
@@ -1,10 +1,10 @@
 ---
-title: Fully Sharded Data Parallel
+title: Fully Sharded Data Parallel (FSDP2)
 sidebar_position: 1
 sidebar_title: Fully Sharded Data Parallel
 ---
 
-# Get Started Training Llama 2 with PyTorch FSDP in 5 Minutes
+# Get Started Training Llama 2 with PyTorch FSDP2 in 5 Minutes
 
 These scripts provide an easy way to get started with multinode [FSDP](https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html) training on Slurm. It is designed to be as simple as possible, requires no data preparation, and uses a simple Conda environment. 
 


### PR DESCRIPTION
EKS:
- Introducing FSDP2 in documentation
- Added "What's New in FSDP2" section
- Docker build now has two targets: base (EKS) and hpto (HyperPod)
- Image tag bumped from pytorch2.5.1 to pytorch2.6.0
- Added HF_TOKEN to HyperPod CLI env vars
- Added FSDP2 implementation details, migration guide, and resources

Slurm:
- Introducing FSDP2 in documentation
- No other changes needed - train.py already uses FSDP2 APIs (fully_shard, MixedPrecisionPolicy, DTensor) under the hood

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction. When we triage the issues, we will add labels to the issue like "Enhancement", "Bug" which should indicate to you that this issue can be worked on and we are looking forward to your PR. We would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/awslabs/ai-on-sagemaker-hyperpod/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [ x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. 
- [ ] Yes, I have added a example to support my blueprint PR.
- [ x] Yes, I have updated the `website/docs` section for this feature.

### For Moderators

- [ x] E2E Test successfully complete before merge?
- [ ] I ran the proper security checks explained on the ML Frameworks wiki

### Additional Notes

<!-- Anything else we should know when reviewing? -->

