### PR TITLE
docs: fix typo and FSx shared file system rendering

### DIFF
--- a/website/docs/00-eks-orchestration/getting-started/Set up your shared file system.md
+++ b/website/docs/00-eks-orchestration/getting-started/Set up your shared file system.md
@@ -185,9 +185,9 @@ Make sure that your file system is located in the same Region and Availability Z
 5. **Verify CSI driver installation**:
    ```bash
    kubectl get pods -n kube-system -l app.kubernetes.io/name=aws-fsx-csi-driver
-```
----
-The [Amazon FSx for Lustre CSI driver](https://github.com/kubernetes-sigs/aws-fsx-csi-driver) presents you with two options for provisioning a file system: 
+   ```
+
+The [Amazon FSx for Lustre CSI driver](https://github.com/kubernetes-sigs/aws-fsx-csi-driver) presents you with two options for provisioning a file system:
 
 #### Create Dynamic Provisioning Resources
 

--- a/website/docs/00-eks-orchestration/getting-started/initial-cluster-setup.md
+++ b/website/docs/00-eks-orchestration/getting-started/initial-cluster-setup.md
@@ -24,6 +24,6 @@ For an EKS-orchestrated Sagemaker Hyperpod, you will need to add at least one in
 
 ![Console experience with a single instance group](/img/01-cluster/orchestrated-by-eks-setup.png)
 
-After you click on Submit, you will see your cluster being created. You can check the console to verify what's the status of this process. When the clsuter shows as **InService** then you can start using it. The whole process usually don't take more than 20 minutes to be ready.
+After you click on Submit, you will see your cluster being created. You can check the console to verify what's the status of this process. When the cluster shows as **InService** then you can start using it. The whole process usually don't take more than 20 minutes to be ready.
 
 ## 

--- a/website/docs/01-slurm-orchestration/getting-started/initial-cluster-setup.md
+++ b/website/docs/01-slurm-orchestration/getting-started/initial-cluster-setup.md
@@ -23,4 +23,4 @@ To get started, navigate to the [SageMaker AI console](https://console.aws.amazo
 
 ![Console experience with a single instance group](/img/01-cluster/orchestrated-by-slurm-setup.png)
 
-After you click on Submit, you will see your cluster being created. You can check the console to verify what's the status of this process. When the clsuter shows as **InService** then you can start using it. The whole process usually don't take more than 20 minutes to be ready.
+After you click on Submit, you will see your cluster being created. You can check the console to verify what's the status of this process. When the cluster shows as **InService** then you can start using it. The whole process usually don't take more than 20 minutes to be ready.


### PR DESCRIPTION
### What does this PR do?

Two small documentation fixes to the getting-started guides:

- Corrects the typo `clsuter` → `cluster` in both the EKS and Slurm `initial-cluster-setup.md` pages.
- Fixes a rendering bug on the EKS `Set up your shared file system` page. Under "Verify CSI driver installation", the bash code block had an unindented closing fence followed by a stray `---` horizontal rule. This caused the FSx CSI driver section that follows ("The Amazon FSx for Lustre CSI driver presents you with two options...") to render as a separate plan-style block instead of continuing the numbered list. Indenting the closing fence and removing the `---` restores the intended flow.

### Motivation

Spotted while reading through the EKS getting-started docs — the typo was minor, but the broken markdown made the FSx section visually disconnect from its parent step list, which is confusing for a first-time reader.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints.
- [ ] Yes, I have added a example to support my blueprint PR.
- [x] Yes, I have updated the `website/docs` section for this feature.

### For Moderators

- [ ] E2E Test successfully complete before merge?
- [ ] I ran the proper security checks explained on the ML Frameworks wiki

### Additional Notes

Documentation-only change. Verified locally by running `npm run start` from `website/` and viewing each affected page.

**Before screenshots:**
<img width="1026" height="826" alt="Screenshot 2026-05-24 at 7 39 43 PM" src="https://github.com/user-attachments/assets/1cf9484d-c71c-473b-a64e-62433afe1943" />

**After screenshots:**
<img width="951" height="612" alt="Screenshot 2026-05-24 at 7 04 29 PM" src="https://github.com/user-attachments/assets/00dde76e-3cf0-4a6f-875b-9c3e18f30294" />

