### PR TITLE
docs: add BYO inference framework KV cache examples

### DIFF
--- a/website/docs/00-eks-orchestration/inference/bring-your-own-inference-framework/00-overview.md
+++ b/website/docs/00-eks-orchestration/inference/bring-your-own-inference-framework/00-overview.md
@@ -1,0 +1,57 @@
+---
+title: Bring Your Own Inference Framework with HyperPod Managed KV Cache
+sidebar_position: 1
+sidebar_label: Overview
+---
+
+# Bring Your Own Inference Framework with HyperPod Managed KV Cache
+
+This guide shows how to run open source inference frameworks on SageMaker HyperPod and reuse HyperPod managed tiered KV cache through LMCache.
+
+The examples cover:
+
+- NVIDIA Dynamo with a Dynamo frontend and vLLM worker
+- llm-d with a vLLM model server
+- SGLang with LMCache IP mode
+
+All three examples use the same HyperPod managed tiered-storage daemon on the GPU node:
+
+```text
+sagemaker-hyperpod://$(NODE_IP):9200
+```
+
+## When To Use This Pattern
+
+Use this pattern when you want HyperPod to provide the managed cluster and KV-cache tiering substrate, but you want to bring your own serving framework, router, or scheduler.
+
+Use the HyperPod Inference Operator path when you want the managed operator workflow and its supported model-serving abstractions.
+
+## Common Architecture
+
+Each example has the same core components:
+
+- A SageMaker HyperPod EKS cluster with GPU nodes
+- HyperPod tiered storage enabled
+- The `ai-toolkit` daemon running on each GPU node
+- A framework-specific serving pod
+- LMCache configured to use the HyperPod daemon as remote storage
+- A store, restart, replay validation that proves KV cache reuse survives the serving pod restart
+
+## Install HyperPod Managed Tiered Storage
+
+Before deploying Dynamo, llm-d, or SGLang, enable HyperPod managed tiered storage on the cluster. Follow the [SageMaker HyperPod managed tiered checkpointing setup guide](https://docs.aws.amazon.com/sagemaker/latest/dg/managed-tier-checkpointing-setup.html).
+
+That setup installs the HyperPod `ai-toolkit` daemon on GPU nodes. The daemon owns the local shared-memory segment and exposes the node-local tiered-storage endpoint that LMCache uses:
+
+```text
+sagemaker-hyperpod://$(NODE_IP):9200
+```
+
+For these examples, verify that:
+
+- The HyperPod cluster has tiered storage enabled.
+- The `ai-toolkit` daemon pod is running on the target GPU node.
+- The node has `/dev/shm/ai_toolkit_cache`.
+- The serving pod mounts `/dev/shm/ai_toolkit_cache` as a `hostPath` file.
+
+The examples in this section are intentionally small and use `Qwen/Qwen3-0.6B` so that they can run on a single-GPU HyperPod node. They were designed for a G6-class GPU instance group and use `g6-workers` as the example HyperPod instance-group label. Replace that value with your GPU instance-group name if your cluster uses a different label.

--- a/website/docs/00-eks-orchestration/inference/bring-your-own-inference-framework/01-hyperpod-managed-kv-cache-with-lmcache.md
+++ b/website/docs/00-eks-orchestration/inference/bring-your-own-inference-framework/01-hyperpod-managed-kv-cache-with-lmcache.md
@@ -1,0 +1,112 @@
+---
+title: HyperPod Managed KV Cache with LMCache
+sidebar_position: 2
+sidebar_label: Managed KV Cache
+---
+
+# HyperPod Managed KV Cache with LMCache
+
+All framework examples in this section use the same LMCache configuration to connect to the HyperPod managed tiered-storage daemon.
+
+## Prerequisites
+
+- A SageMaker HyperPod EKS cluster with a GPU instance group
+- Tiered storage enabled on the HyperPod cluster
+- `kubectl` configured for the HyperPod EKS cluster
+- A GPU node where the `ai-toolkit` daemon has created `/dev/shm/ai_toolkit_cache`
+
+When creating or updating a HyperPod cluster, tiered storage is enabled with a `TieredStorageConfig` block. For example:
+
+```json
+{
+  "Mode": "Enable",
+  "InstanceMemoryAllocationPercentage": 20
+}
+```
+
+## Shared LMCache Config
+
+Use this shared configuration shape:
+
+```yaml
+chunk_size: 256
+local_cpu: true
+max_local_cpu_size: 4
+save_unfull_chunk: true
+remote_url: "sagemaker-hyperpod://PLACEHOLDER_NODE_IP:9200"
+remote_serde: "naive"
+extra_config:
+  sagemaker_hyperpod_shared_memory_name: ai_toolkit_cache
+```
+
+For vLLM-based examples, `remote_url` is supplied by the `LMCACHE_REMOTE_URL` environment variable:
+
+```bash
+LMCACHE_REMOTE_URL=sagemaker-hyperpod://$(NODE_IP):9200
+```
+
+SGLang reads `remote_url` from its LMCache config file, so the SGLang example renders the node IP into the file at container startup.
+
+The serving pod should get `NODE_IP` from the Kubernetes downward API:
+
+```yaml
+- name: NODE_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.hostIP
+```
+
+## Manifest Mapping
+
+The settings above are translated into the example manifests as follows:
+
+| Intent | Manifest field |
+| --- | --- |
+| Enable HyperPod L2 KV cache storage | HyperPod cluster `TieredStorageConfig` before applying the workload manifest |
+| Point LMCache at the node-local HyperPod daemon | `LMCACHE_REMOTE_URL=sagemaker-hyperpod://$(NODE_IP):9200` for vLLM, or `remote_url` in the SGLang LMCache config file |
+| Resolve `$(NODE_IP)` to the GPU node host IP | `env[].valueFrom.fieldRef.fieldPath: status.hostIP` |
+| Tell LMCache the HyperPod shared-memory segment name | `extra_config.sagemaker_hyperpod_shared_memory_name: ai_toolkit_cache` |
+| Keep partial prompt chunks available for the restart/replay proof | `save_unfull_chunk: true` |
+| Mount the HyperPod daemon shared-memory segment into the serving pod | `volumeMounts[].mountPath: /dev/shm/ai_toolkit_cache` with `hostPath.type: File` |
+| Keep replay keys stable across process restart | `PYTHONHASHSEED=0` |
+
+For Dynamo and llm-d, these fields are in the workload manifest ConfigMap and container environment. For SGLang, the manifest renders the node IP into the LMCache config file before launching the server.
+
+## Shared Memory Mount
+
+Mount the daemon-owned shared memory file, not the whole `/dev/shm` directory:
+
+```yaml
+volumeMounts:
+  - name: hp-tiered-cache
+    mountPath: /dev/shm/ai_toolkit_cache
+
+volumes:
+  - name: hp-tiered-cache
+    hostPath:
+      path: /dev/shm/ai_toolkit_cache
+      type: File
+```
+
+Mounting the whole `/dev/shm` directory can allow a terminating client process to unlink the daemon-owned segment. The examples use a file mount to avoid that failure mode.
+
+## Runtime Settings
+
+Use `PYTHONHASHSEED=0` for deterministic store, restart, replay validation. The replay request must produce the same LMCache keys after the serving process restarts:
+
+```yaml
+- name: PYTHONHASHSEED
+  value: "0"
+```
+
+## Validation
+
+A successful L2 validation requires a store, restart, replay flow:
+
+1. Send a deterministic prompt through the framework frontend.
+2. Confirm LMCache stores the prompt KV cache to HyperPod L2.
+3. Restart only the serving pod or deployment.
+4. Replay the exact same prompt.
+5. Confirm a cache hit after restart.
+
+Use [Validate Cache Reuse](./05-validate-kv-cache-reuse.md) for the commands and metrics/log checks.

--- a/website/docs/00-eks-orchestration/inference/bring-your-own-inference-framework/02-deploy-dynamo-with-lmcache.md
+++ b/website/docs/00-eks-orchestration/inference/bring-your-own-inference-framework/02-deploy-dynamo-with-lmcache.md
@@ -1,0 +1,82 @@
+---
+title: Deploy Dynamo with LMCache
+sidebar_position: 3
+sidebar_label: Dynamo
+---
+
+# Deploy Dynamo with LMCache
+
+This example runs a Dynamo frontend and Dynamo vLLM worker on HyperPod. The vLLM worker uses LMCache to read and write KV cache through the HyperPod managed tiered-storage daemon.
+
+## Deploy
+
+Download or copy `dynamo-vllm-lmcache-hyperpod.yaml`, then apply it:
+
+```bash
+kubectl apply -f dynamo-vllm-lmcache-hyperpod.yaml
+kubectl rollout status deployment/dynamo-lmcache-frontend -n dynamo-hp-lmcache --timeout=15m
+kubectl rollout status deployment/dynamo-lmcache-worker -n dynamo-hp-lmcache --timeout=15m
+```
+
+The manifest runs the Dynamo frontend and vLLM worker as separate Deployments. For this single-node example, both pods share a node-local file-discovery directory. For production multi-node deployments, use a production discovery backend such as etcd or DNS.
+
+## Test The Frontend
+
+Start the frontend port-forward:
+
+```bash
+kubectl port-forward -n dynamo-hp-lmcache svc/dynamo-lmcache-frontend 18000:8000
+```
+
+In a second terminal, start the worker metrics port-forward:
+
+```bash
+kubectl port-forward -n dynamo-hp-lmcache svc/dynamo-lmcache-worker-metrics 18081:8081
+```
+
+Then query the frontend:
+
+```bash
+curl -s http://127.0.0.1:18000/v1/models
+curl -s http://127.0.0.1:18000/health
+```
+
+The health response should list a backend `generate` endpoint:
+
+```text
+dyn://dynamo-hp-lmcache.backend.generate
+```
+
+## Prove L2 Reuse
+
+Download or copy `validate-kv-cache-reuse.py`, then run the shared probe:
+
+```bash
+python3 validate-kv-cache-reuse.py \
+  --base-url http://127.0.0.1:18000 \
+  --metrics-url http://127.0.0.1:18081/metrics \
+  --phase store \
+  --output dynamo-store.json
+
+kubectl rollout restart deployment/dynamo-lmcache-worker -n dynamo-hp-lmcache
+kubectl rollout status deployment/dynamo-lmcache-worker -n dynamo-hp-lmcache --timeout=15m
+
+python3 validate-kv-cache-reuse.py \
+  --base-url http://127.0.0.1:18000 \
+  --metrics-url http://127.0.0.1:18081/metrics \
+  --phase replay \
+  --output dynamo-replay.json
+```
+
+Expected replay evidence:
+
+```text
+cached_tokens > 0
+vllm:external_prefix_cache_hits_total > 0
+lmcache:num_hit_tokens_total > 0
+lmcache:num_remote_read_requests_total > 0
+```
+
+## Notes
+
+For `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1`, use vLLM's `--kv-transfer-config` form. The older `--connector lmcache` helper may be rejected by this image.

--- a/website/docs/00-eks-orchestration/inference/bring-your-own-inference-framework/03-deploy-llm-d-with-lmcache.md
+++ b/website/docs/00-eks-orchestration/inference/bring-your-own-inference-framework/03-deploy-llm-d-with-lmcache.md
@@ -1,0 +1,66 @@
+---
+title: Deploy llm-d with LMCache
+sidebar_position: 4
+sidebar_label: llm-d
+---
+
+# Deploy llm-d with LMCache
+
+This example uses llm-d as the serving framework and configures its vLLM model server to use LMCache with HyperPod managed tiered storage.
+
+## Deploy
+
+Install llm-d following the upstream llm-d guide for your gateway provider and model service. Then apply the HyperPod LMCache overlay in `llm-d-vllm-lmcache-hyperpod.yaml`.
+
+At minimum, the model server must include:
+
+- `LMCacheConnectorV1` in vLLM `--kv-transfer-config`
+- `LMCACHE_REMOTE_URL=sagemaker-hyperpod://$(NODE_IP):9200`
+- `LMCACHE_CONFIG_FILE=/etc/lmcache/config.yaml`
+- A file mount for `/dev/shm/ai_toolkit_cache`
+
+For a minimal model-server deployment:
+
+```bash
+kubectl apply -f llm-d-vllm-lmcache-hyperpod.yaml
+kubectl rollout status deployment/llmd-lmcache-decode -n llm-d-hp-lmcache --timeout=15m
+```
+
+## Validate
+
+Port-forward the llm-d gateway or the model server service, depending on your deployment:
+
+```bash
+kubectl port-forward -n llm-d-hp-lmcache svc/llmd-lmcache-decode 18000:8000
+```
+
+Download or copy `validate-kv-cache-reuse.py`, then run the shared probe:
+
+```bash
+python3 validate-kv-cache-reuse.py \
+  --base-url http://127.0.0.1:18000 \
+  --metrics-url http://127.0.0.1:18000/metrics \
+  --phase store \
+  --output llmd-store.json
+
+kubectl rollout restart deployment/llmd-lmcache-decode -n llm-d-hp-lmcache
+kubectl rollout status deployment/llmd-lmcache-decode -n llm-d-hp-lmcache --timeout=15m
+
+python3 validate-kv-cache-reuse.py \
+  --base-url http://127.0.0.1:18000 \
+  --metrics-url http://127.0.0.1:18000/metrics \
+  --phase replay \
+  --output llmd-replay.json
+```
+
+Expected replay evidence:
+
+```text
+cached_tokens > 0
+external_prefix_cache_hits_total > 0
+Retrieved N out of N required tokens
+```
+
+## Notes
+
+If the llm-d gateway or router runs on a non-HyperPod node, verify pod-to-pod routing to the HyperPod GPU node. In restricted network layouts, colocating the gateway/router path with the HyperPod node may be required.

--- a/website/docs/00-eks-orchestration/inference/bring-your-own-inference-framework/04-deploy-sglang-with-lmcache.md
+++ b/website/docs/00-eks-orchestration/inference/bring-your-own-inference-framework/04-deploy-sglang-with-lmcache.md
@@ -1,0 +1,62 @@
+---
+title: Deploy SGLang with LMCache
+sidebar_position: 5
+sidebar_label: SGLang
+---
+
+# Deploy SGLang with LMCache
+
+This example runs SGLang on HyperPod and uses LMCache to read and write KV cache through the HyperPod managed tiered-storage daemon.
+
+## Deploy
+
+Download or copy `sglang-lmcache-hyperpod.yaml`, then apply it:
+
+```bash
+kubectl apply -f sglang-lmcache-hyperpod.yaml
+kubectl rollout status deployment/sglang-lmcache -n sglang-hp-lmcache --timeout=15m
+```
+
+The example uses `lmsysorg/sglang:v0.5.15-cu130`, installs `lmcache==0.5.1` at startup, and launches SGLang with:
+
+```text
+--enable-lmcache --lmcache-config-file /tmp/lmcache.yaml
+```
+
+## Validate
+
+```bash
+kubectl port-forward -n sglang-hp-lmcache svc/sglang-lmcache 18000:8000
+```
+
+Download or copy `validate-kv-cache-reuse.py`. SGLang exposes a `/generate` endpoint. Send a deterministic long prefix, restart the pod, then replay the exact same prompt:
+
+```bash
+python3 validate-kv-cache-reuse.py \
+  --base-url http://127.0.0.1:18000 \
+  --endpoint-mode sglang \
+  --phase store \
+  --output sglang-store.json
+
+kubectl rollout restart deployment/sglang-lmcache -n sglang-hp-lmcache
+kubectl rollout status deployment/sglang-lmcache -n sglang-hp-lmcache --timeout=15m
+
+python3 validate-kv-cache-reuse.py \
+  --base-url http://127.0.0.1:18000 \
+  --endpoint-mode sglang \
+  --phase replay \
+  --output sglang-replay.json
+```
+
+Expected replay evidence:
+
+```text
+cached_tokens > 0
+LMCache retrieve started
+```
+
+## SGLang-Specific Notes
+
+SGLang's LMCache integration may need IP mode to pass the full LMCache config, including `remote_url`, to LMCache. This workaround was validated with `lmsysorg/sglang:v0.5.15-cu130` and `lmcache==0.5.1`. The example manifest guards and then patches SGLang's LMCache mode at startup, and sets `use_layerwise: true` in the LMCache config.
+
+If a newer SGLang release exposes LMCache IP mode through a CLI or config option, prefer that over the startup patch.

--- a/website/docs/00-eks-orchestration/inference/bring-your-own-inference-framework/05-validate-kv-cache-reuse.md
+++ b/website/docs/00-eks-orchestration/inference/bring-your-own-inference-framework/05-validate-kv-cache-reuse.md
@@ -1,0 +1,123 @@
+---
+title: Validate KV Cache Reuse
+sidebar_position: 6
+sidebar_label: Validate Cache Reuse
+---
+
+# Validate KV Cache Reuse
+
+The core test is the same for every framework:
+
+1. Send a deterministic prompt.
+2. Confirm the serving process stores KV cache to HyperPod L2.
+3. Restart the serving deployment.
+4. Replay the exact same prompt.
+5. Confirm the replay reads from L2.
+
+## Why Restart?
+
+Restarting the serving pod clears process-local state and GPU KV cache. If replay shows a hit after restart, the surviving source is the HyperPod managed tiered-storage daemon.
+
+## Shared Probe
+
+Download or copy `validate-kv-cache-reuse.py`. For OpenAI-compatible vLLM paths, pass the metrics URL that matches the framework service you port-forwarded:
+
+| Framework | Metrics URL |
+| --- | --- |
+| Dynamo | `http://127.0.0.1:18081/metrics` |
+| llm-d | `http://127.0.0.1:18000/metrics` |
+| SGLang | Omit `--metrics-url`; use log-based evidence |
+
+For Dynamo:
+
+```bash
+python3 validate-kv-cache-reuse.py \
+  --base-url http://127.0.0.1:18000 \
+  --metrics-url http://127.0.0.1:18081/metrics \
+  --phase store \
+  --output store.json
+```
+
+For llm-d:
+
+```bash
+python3 validate-kv-cache-reuse.py \
+  --base-url http://127.0.0.1:18000 \
+  --metrics-url http://127.0.0.1:18000/metrics \
+  --phase store \
+  --output store.json
+```
+
+Then restart the serving deployment and replay with the same framework-specific metrics URL. Dynamo uses the worker metrics service:
+
+```bash
+python3 validate-kv-cache-reuse.py \
+  --base-url http://127.0.0.1:18000 \
+  --metrics-url http://127.0.0.1:18081/metrics \
+  --phase replay \
+  --output replay.json
+```
+
+llm-d exposes metrics on the same service as the OpenAI-compatible API:
+
+```bash
+python3 validate-kv-cache-reuse.py \
+  --base-url http://127.0.0.1:18000 \
+  --metrics-url http://127.0.0.1:18000/metrics \
+  --phase replay \
+  --output replay.json
+```
+
+For SGLang, add `--endpoint-mode sglang` and omit `--metrics-url` unless you expose framework metrics separately.
+
+## Inspect Replay Evidence
+
+The probe writes the response usage and selected metrics into the replay artifact. Start there:
+
+```bash
+jq '.request.usage, .selected_metrics_after[]?' replay.json
+```
+
+For vLLM-based examples, also query the metrics endpoint directly while the port-forward is still running:
+
+```bash
+curl -s http://127.0.0.1:18081/metrics | grep -E 'vllm:external_prefix_cache|lmcache:num_hit_tokens|lmcache:num_remote_read'
+```
+
+If the vLLM service exposes metrics on the same port as the OpenAI API, use:
+
+```bash
+curl -s http://127.0.0.1:18000/metrics | grep -E 'vllm:external_prefix_cache|lmcache:num_hit_tokens|lmcache:num_remote_read'
+```
+
+For log-based confirmation, check the serving deployment logs after the replay request:
+
+```bash
+kubectl logs -n dynamo-hp-lmcache deployment/dynamo-lmcache-worker --since=10m | grep -E 'Retrieved [0-9]+ out of|LMCache|remote read'
+kubectl logs -n llm-d-hp-lmcache deployment/llmd-lmcache-decode --since=10m | grep -E 'Retrieved [0-9]+ out of|LMCache|remote read'
+kubectl logs -n sglang-hp-lmcache deployment/sglang-lmcache --since=10m | grep -E 'LMCache retrieve|cached_tokens|remote read'
+```
+
+The strongest replay proof is a post-restart request with nonzero cached tokens plus LMCache remote-read or retrieve evidence.
+
+## Passing Signals
+
+Strong passing signals:
+
+```text
+usage.prompt_tokens_details.cached_tokens > 0
+vllm:external_prefix_cache_hits_total > 0
+lmcache:num_hit_tokens_total > 0
+lmcache:num_remote_read_requests_total > 0
+Retrieved N out of N required tokens
+```
+
+Store-only signals:
+
+```text
+lmcache:num_stored_tokens_total > 0
+lmcache:num_remote_write_requests_total > 0
+PUT success
+```
+
+Store-only signals prove the write path, but not L2 reuse. A complete pass requires post-restart read evidence.

--- a/website/docs/00-eks-orchestration/inference/bring-your-own-inference-framework/06-troubleshooting.md
+++ b/website/docs/00-eks-orchestration/inference/bring-your-own-inference-framework/06-troubleshooting.md
@@ -1,0 +1,43 @@
+---
+title: Troubleshooting
+sidebar_position: 7
+sidebar_label: Troubleshooting
+---
+
+# Troubleshooting
+
+## LMCache Looks For `shared_memory`
+
+The HyperPod adapter must receive the shared memory name through LMCache config:
+
+```yaml
+extra_config:
+  sagemaker_hyperpod_shared_memory_name: ai_toolkit_cache
+```
+
+Passing the name only in vLLM `kv_connector_extra_config` may not be enough.
+
+## The Shared Memory Segment Is Missing
+
+The examples mount `/dev/shm/ai_toolkit_cache` with `hostPath.type: File`. That file must already exist on the GPU node.
+
+If it is missing, restart the HyperPod `ai-toolkit` daemon pod on that node, then redeploy the serving workload.
+
+## Store Works But Replay Misses
+
+Start with the store, restart, replay commands in [Validate Cache Reuse](./05-validate-kv-cache-reuse.md), then check:
+
+- `PYTHONHASHSEED=0` is set before the server starts.
+- `save_unfull_chunk: true` is set.
+- The replay prompt is byte-for-byte identical.
+- You restarted only the serving pod, not the HyperPod `ai-toolkit` daemon.
+- The prompt is long enough to cross the LMCache chunk threshold.
+
+## Pod Does Not Schedule
+
+The example manifests use `g6-workers` as the HyperPod instance-group label. If your cluster uses a different GPU instance group, update:
+
+```yaml
+nodeSelector:
+  sagemaker.amazonaws.com/instance-group-name: g6-workers
+```

--- a/website/docs/00-eks-orchestration/inference/bring-your-own-inference-framework/_category_.json
+++ b/website/docs/00-eks-orchestration/inference/bring-your-own-inference-framework/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Bring Your Own Inference Framework",
+  "position": 4,
+  "link": {
+    "type": "generated-index",
+    "description": "Deploy Dynamo, llm-d, and SGLang on SageMaker HyperPod while reusing HyperPod managed KV cache through LMCache."
+  }
+}

--- a/website/static/examples/inference/bring-your-own-inference-framework/common/lmcache-hyperpod-config.yaml
+++ b/website/static/examples/inference/bring-your-own-inference-framework/common/lmcache-hyperpod-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lmcache-hyperpod-config
+data:
+  config.yaml: |
+    chunk_size: 256
+    local_cpu: true
+    max_local_cpu_size: 4
+    save_unfull_chunk: true
+    extra_config:
+      sagemaker_hyperpod_shared_memory_name: ai_toolkit_cache

--- a/website/static/examples/inference/bring-your-own-inference-framework/common/validate-kv-cache-reuse.py
+++ b/website/static/examples/inference/bring-your-own-inference-framework/common/validate-kv-cache-reuse.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Store/replay probe for HyperPod managed KV cache examples.
+
+The probe sends a deterministic long-prefix request, optionally scrapes metrics,
+and writes a JSON artifact. Run it once before restarting the serving deployment
+with --phase store, then run it again with --phase replay after the restart.
+"""
+
+import argparse
+import json
+import time
+import urllib.request
+from pathlib import Path
+
+
+DEFAULT_MODEL = "Qwen/Qwen3-0.6B"
+METRIC_PREFIXES = (
+    "vllm:external_prefix_cache",
+    "vllm:prefix_cache",
+    "vllm:request_success_total",
+    "lmcache:num_",
+    "lmcache:lookup",
+    "lmcache:retrieve",
+    "lmcache:remote",
+)
+PROMPT_PHRASE = "SageMaker HyperPod LMCache managed L2 replay stable key. "
+PROMPT_REPEATS = 45
+
+
+def request(method, url, body=None, timeout=10):
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    headers = {} if body is None else {"Content-Type": "application/json"}
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        return response.status, response.read().decode("utf-8")
+
+
+def selected_metrics(metrics_url):
+    if not metrics_url:
+        return []
+    try:
+        _, text = request("GET", metrics_url, timeout=10)
+    except Exception as exc:
+        return [f"# metrics fetch failed: {exc}"]
+    return [line for line in text.splitlines() if line.startswith(METRIC_PREFIXES)]
+
+
+def build_prompt():
+    prefix = PROMPT_PHRASE * PROMPT_REPEATS
+    prompt = prefix + "\nAnswer in one short sentence: what cache path is being validated?"
+    return prompt, len(prefix)
+
+
+def openai_request(base_url, model, prompt, max_tokens):
+    body = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": 0,
+        "stream": False,
+    }
+    status, raw = request("POST", f"{base_url}/v1/chat/completions", body=body, timeout=180)
+    response = json.loads(raw)
+    choice = response.get("choices", [{}])[0]
+    message = choice.get("message", {})
+    return status, response, {
+        "usage": response.get("usage"),
+        "finish_reason": choice.get("finish_reason"),
+        "content": message.get("content", "")[:240],
+    }
+
+
+def sglang_request(base_url, model, prompt, max_tokens):
+    body = {
+        "text": prompt,
+        "sampling_params": {
+            "temperature": 0,
+            "max_new_tokens": max_tokens,
+        },
+    }
+    status, raw = request("POST", f"{base_url}/generate", body=body, timeout=180)
+    response = json.loads(raw)
+    return status, response, {
+        "usage": response.get("meta_info"),
+        "finish_reason": response.get("finish_reason"),
+        "content": str(response.get("text", ""))[:240],
+    }
+
+
+def try_get(url):
+    try:
+        status, raw = request("GET", url, timeout=10)
+        return {"status": status, "body": raw[:1000]}
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+def run(args):
+    base_url = args.base_url.rstrip("/")
+    prompt, common_prefix_chars = build_prompt()
+
+    health = try_get(f"{base_url}/health")
+    models = try_get(f"{base_url}/v1/models") if args.endpoint_mode == "openai" else None
+    metrics_before = selected_metrics(args.metrics_url)
+
+    start = time.time()
+    if args.endpoint_mode == "openai":
+        status, raw_response, request_summary = openai_request(
+            base_url, args.model, prompt, args.max_tokens
+        )
+    else:
+        status, raw_response, request_summary = sglang_request(
+            base_url, args.model, prompt, args.max_tokens
+        )
+    latency_ms = round((time.time() - start) * 1000, 2)
+
+    time.sleep(args.metrics_settle_seconds)
+    metrics_after = selected_metrics(args.metrics_url)
+
+    artifact = {
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "phase": args.phase,
+        "endpoint_mode": args.endpoint_mode,
+        "endpoint": base_url,
+        "model": args.model,
+        "common_prefix_chars": common_prefix_chars,
+        "health": health,
+        "models": models,
+        "request": {
+            "status": status,
+            "latency_ms": latency_ms,
+            **request_summary,
+        },
+        "selected_metrics_before": metrics_before,
+        "selected_metrics_after": metrics_after,
+        "raw_response": raw_response,
+    }
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(artifact, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({"output": str(output), "request": artifact["request"]}, indent=2))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--phase", choices=["store", "replay"], required=True)
+    parser.add_argument("--base-url", default="http://127.0.0.1:18000")
+    parser.add_argument("--metrics-url", default=None)
+    parser.add_argument("--endpoint-mode", choices=["openai", "sglang"], default="openai")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--max-tokens", type=int, default=16)
+    parser.add_argument("--metrics-settle-seconds", type=float, default=2.0)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/website/static/examples/inference/bring-your-own-inference-framework/dynamo/dynamo-vllm-lmcache-hyperpod.yaml
+++ b/website/static/examples/inference/bring-your-own-inference-framework/dynamo/dynamo-vllm-lmcache-hyperpod.yaml
@@ -1,0 +1,256 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dynamo-hp-lmcache
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lmcache-hyperpod-config
+  namespace: dynamo-hp-lmcache
+data:
+  config.yaml: |
+    chunk_size: 256
+    local_cpu: true
+    max_local_cpu_size: 4
+    save_unfull_chunk: true
+    extra_config:
+      sagemaker_hyperpod_shared_memory_name: ai_toolkit_cache
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dynamo-lmcache-frontend
+  namespace: dynamo-hp-lmcache
+spec:
+  type: ClusterIP
+  selector:
+    app: dynamo-lmcache-frontend
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dynamo-lmcache-worker-metrics
+  namespace: dynamo-hp-lmcache
+spec:
+  type: ClusterIP
+  selector:
+    app: dynamo-lmcache-worker
+  ports:
+    - name: metrics
+      port: 8081
+      targetPort: 8081
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dynamo-lmcache-frontend
+  namespace: dynamo-hp-lmcache
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: dynamo-lmcache-frontend
+  template:
+    metadata:
+      labels:
+        app: dynamo-lmcache-frontend
+    spec:
+      nodeSelector:
+        sagemaker.amazonaws.com/instance-group-name: g6-workers
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: dynamo-lmcache-worker
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: dynamo-frontend
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+          command: ["/bin/bash", "-lc"]
+          args:
+            - |
+              set -euo pipefail
+              mkdir -p /dynamo-store
+              export DYN_FILE_KV=/dynamo-store
+
+              exec python3 -m dynamo.frontend \
+                --namespace dynamo-hp-lmcache \
+                --http-port 8000 \
+                --discovery-backend file \
+                --request-plane tcp \
+                --event-plane zmq \
+                --router-mode round-robin \
+                --model-name Qwen/Qwen3-0.6B
+          env:
+            - name: DYN_SYSTEM_PORT
+              value: "8081"
+          ports:
+            - containerPort: 8000
+              name: http
+            - containerPort: 8081
+              name: metrics
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+            limits:
+              cpu: "1"
+              memory: 4Gi
+          volumeMounts:
+            - name: dynamo-discovery
+              mountPath: /dynamo-store
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+      volumes:
+        - name: dynamo-discovery
+          hostPath:
+            # Node-local file discovery keeps the G6 example simple. Use etcd
+            # or DNS discovery for production multi-node Dynamo deployments.
+            path: /tmp/dynamo-file-discovery/dynamo-hp-lmcache
+            type: DirectoryOrCreate
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dynamo-lmcache-worker
+  namespace: dynamo-hp-lmcache
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: dynamo-lmcache-worker
+  template:
+    metadata:
+      labels:
+        app: dynamo-lmcache-worker
+    spec:
+      nodeSelector:
+        sagemaker.amazonaws.com/instance-group-name: g6-workers
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: dynamo-vllm
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+          command: ["/bin/bash", "-lc"]
+          args:
+            - |
+              set -euo pipefail
+              mkdir -p /dynamo-store
+              export DYN_FILE_KV=/dynamo-store
+
+              exec python3 -m dynamo.vllm \
+                --namespace dynamo-hp-lmcache \
+                --discovery-backend file \
+                --request-plane tcp \
+                --event-plane zmq \
+                --model Qwen/Qwen3-0.6B \
+                --enable-prefix-caching \
+                --max-model-len 8192 \
+                --gpu-memory-utilization 0.70 \
+                --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both","kv_connector_extra_config":{"sagemaker_hyperpod_shared_memory_name":"ai_toolkit_cache"}}'
+          env:
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: LMCACHE_CONFIG_FILE
+              value: /etc/lmcache/config.yaml
+            - name: LMCACHE_USE_EXPERIMENTAL
+              value: "True"
+            - name: LMCACHE_LOCAL_CPU
+              value: "True"
+            - name: LMCACHE_MAX_LOCAL_CPU_SIZE
+              value: "4"
+            - name: LMCACHE_CHUNK_SIZE
+              value: "256"
+            - name: LMCACHE_REMOTE_URL
+              value: sagemaker-hyperpod://$(NODE_IP):9200
+            - name: DYN_SYSTEM_PORT
+              value: "8081"
+            - name: PYTHONHASHSEED
+              value: "0"
+          ports:
+            - containerPort: 8081
+              name: metrics
+          resources:
+            requests:
+              cpu: 500m
+              memory: 10Gi
+              nvidia.com/gpu: "1"
+            limits:
+              cpu: "1500m"
+              memory: 24Gi
+              nvidia.com/gpu: "1"
+          volumeMounts:
+            - name: hp-tiered-cache
+              mountPath: /dev/shm/ai_toolkit_cache
+            - name: dynamo-discovery
+              mountPath: /dynamo-store
+            - name: lmcache-config
+              mountPath: /etc/lmcache
+              readOnly: true
+          startupProbe:
+            exec:
+              command: ["pgrep", "-f", "dynamo.vllm"]
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command: ["pgrep", "-f", "dynamo.vllm"]
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["pgrep", "-f", "dynamo.vllm"]
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+      volumes:
+        - name: hp-tiered-cache
+          hostPath:
+            path: /dev/shm/ai_toolkit_cache
+            type: File
+        - name: dynamo-discovery
+          hostPath:
+            # Node-local file discovery keeps the G6 example simple. Use etcd
+            # or DNS discovery for production multi-node Dynamo deployments.
+            path: /tmp/dynamo-file-discovery/dynamo-hp-lmcache
+            type: DirectoryOrCreate
+        - name: lmcache-config
+          configMap:
+            name: lmcache-hyperpod-config

--- a/website/static/examples/inference/bring-your-own-inference-framework/llm-d/llm-d-vllm-lmcache-hyperpod.yaml
+++ b/website/static/examples/inference/bring-your-own-inference-framework/llm-d/llm-d-vllm-lmcache-hyperpod.yaml
@@ -1,0 +1,147 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: llm-d-hp-lmcache
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lmcache-hyperpod-config
+  namespace: llm-d-hp-lmcache
+data:
+  config.yaml: |
+    chunk_size: 256
+    local_cpu: true
+    max_local_cpu_size: 4
+    save_unfull_chunk: true
+    extra_config:
+      sagemaker_hyperpod_shared_memory_name: ai_toolkit_cache
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llmd-lmcache-decode
+  namespace: llm-d-hp-lmcache
+spec:
+  type: ClusterIP
+  selector:
+    app: llmd-lmcache-decode
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llmd-lmcache-decode
+  namespace: llm-d-hp-lmcache
+  labels:
+    app: llmd-lmcache-decode
+    llm-d.ai/role: decode
+    llm-d.ai/guide: hyperpod-managed-kv-cache
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: llmd-lmcache-decode
+  template:
+    metadata:
+      labels:
+        app: llmd-lmcache-decode
+        llm-d.ai/role: decode
+        llm-d.ai/guide: hyperpod-managed-kv-cache
+    spec:
+      nodeSelector:
+        sagemaker.amazonaws.com/instance-group-name: g6-workers
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: modelserver
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+          command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8000"
+            - --enable-prefix-caching
+            - --max-model-len
+            - "8192"
+            - --gpu-memory-utilization
+            - "0.70"
+            - --kv-transfer-config
+            - '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both","kv_connector_extra_config":{"sagemaker_hyperpod_shared_memory_name":"ai_toolkit_cache"}}'
+          env:
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: LMCACHE_CONFIG_FILE
+              value: /etc/lmcache/config.yaml
+            - name: LMCACHE_USE_EXPERIMENTAL
+              value: "True"
+            - name: LMCACHE_LOCAL_CPU
+              value: "True"
+            - name: LMCACHE_MAX_LOCAL_CPU_SIZE
+              value: "4"
+            - name: LMCACHE_CHUNK_SIZE
+              value: "256"
+            - name: LMCACHE_REMOTE_URL
+              value: sagemaker-hyperpod://$(NODE_IP):9200
+            - name: PYTHONHASHSEED
+              value: "0"
+          ports:
+            - containerPort: 8000
+              name: http
+          resources:
+            requests:
+              cpu: 500m
+              memory: 10Gi
+              nvidia.com/gpu: "1"
+            limits:
+              cpu: "1500m"
+              memory: 24Gi
+              nvidia.com/gpu: "1"
+          volumeMounts:
+            - name: hp-tiered-cache
+              mountPath: /dev/shm/ai_toolkit_cache
+            - name: lmcache-config
+              mountPath: /etc/lmcache
+              readOnly: true
+          startupProbe:
+            httpGet:
+              path: /v1/models
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+      volumes:
+        - name: hp-tiered-cache
+          hostPath:
+            path: /dev/shm/ai_toolkit_cache
+            type: File
+        - name: lmcache-config
+          configMap:
+            name: lmcache-hyperpod-config

--- a/website/static/examples/inference/bring-your-own-inference-framework/sglang/sglang-lmcache-hyperpod.yaml
+++ b/website/static/examples/inference/bring-your-own-inference-framework/sglang/sglang-lmcache-hyperpod.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sglang-hp-lmcache
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lmcache-hyperpod-config-template
+  namespace: sglang-hp-lmcache
+data:
+  config.yaml: |
+    chunk_size: 256
+    local_cpu: true
+    max_local_cpu_size: 4
+    save_unfull_chunk: true
+    use_layerwise: true
+    remote_url: "sagemaker-hyperpod://NODE_IP_PLACEHOLDER:9200"
+    remote_serde: "naive"
+    extra_config:
+      sagemaker_hyperpod_shared_memory_name: ai_toolkit_cache
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sglang-lmcache
+  namespace: sglang-hp-lmcache
+spec:
+  type: ClusterIP
+  selector:
+    app: sglang-lmcache
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sglang-lmcache
+  namespace: sglang-hp-lmcache
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: sglang-lmcache
+  template:
+    metadata:
+      labels:
+        app: sglang-lmcache
+    spec:
+      nodeSelector:
+        sagemaker.amazonaws.com/instance-group-name: g6-workers
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: sglang
+          image: lmsysorg/sglang:v0.5.15-cu130
+          command: ["/bin/bash", "-lc"]
+          args:
+            - |
+              set -euo pipefail
+              pip install -q lmcache==0.5.1
+              lmcache_file=$(python3 -c 'import sglang.srt.mem_cache.storage.lmcache.lmc_radix_cache as m; print(m.__file__)')
+              if ! grep -q 'self._mode = LMCacheMode.MP' "$lmcache_file"; then
+                echo "ERROR: SGLang LMCache mode patch target not found; the SGLang API may have changed." >&2
+                echo "This example was validated against lmsysorg/sglang:v0.5.15-cu130 with lmcache==0.5.1." >&2
+                echo "Check whether SGLang now supports LMCache IP mode through a CLI or config option." >&2
+                exit 1
+              fi
+              sed -i 's/self\._mode = LMCacheMode\.MP/self._mode = LMCacheMode.IP/' "$lmcache_file"
+              sed "s/NODE_IP_PLACEHOLDER/${NODE_IP}/" /etc/lmcache-template/config.yaml > /tmp/lmcache.yaml
+
+              exec python3 -m sglang.launch_server \
+                --model-path Qwen/Qwen3-0.6B \
+                --host 0.0.0.0 \
+                --port 8000 \
+                --mem-fraction-static 0.70 \
+                --context-length 8192 \
+                --enable-lmcache \
+                --lmcache-config-file /tmp/lmcache.yaml
+          env:
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: PYTHONHASHSEED
+              value: "0"
+          ports:
+            - containerPort: 8000
+              name: http
+          resources:
+            requests:
+              cpu: 500m
+              memory: 12Gi
+              nvidia.com/gpu: "1"
+            limits:
+              cpu: "1500m"
+              memory: 26Gi
+              nvidia.com/gpu: "1"
+          volumeMounts:
+            - name: hp-tiered-cache
+              mountPath: /dev/shm/ai_toolkit_cache
+            - name: lmcache-template
+              mountPath: /etc/lmcache-template
+              readOnly: true
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 40
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 80
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+      volumes:
+        - name: hp-tiered-cache
+          hostPath:
+            path: /dev/shm/ai_toolkit_cache
+            type: File
+        - name: lmcache-template
+          configMap:
+            name: lmcache-hyperpod-config-template


### PR DESCRIPTION
### What does this PR do?

Adds a new Docusaurus docs section for **Bring Your Own Inference Framework with HyperPod Managed KV Cache** under EKS inference.

This includes:
- Dynamo + LMCache + HyperPod managed tiered KV cache example
- llm-d + LMCache + HyperPod managed tiered KV cache example
- SGLang + LMCache + HyperPod managed tiered KV cache example
- Shared LMCache/HyperPod configuration guidance
- Store, restart, replay validation workflow
- Sanitized Kubernetes manifests and a reusable validation probe

### Motivation

These examples show how users can bring their own inference framework while reusing SageMaker HyperPod managed tiered KV cache through LMCache. The examples are intentionally small and use `Qwen/Qwen3-0.6B` on a single-GPU G6-class HyperPod instance group so they are easier to reproduce.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints.
- [x] Yes, I have added a example to support my blueprint PR.
- [x] Yes, I have updated the `website/docs` section for this feature.

### For Moderators

- [ ] E2E Test successfully complete before merge?
- [ ] I ran the proper security checks explained on the ML Frameworks wiki

### Additional Notes

Local validation completed:
- `npm ci` in `website`
- `npm run build` in `website`
- YAML parse check for added example manifests
- Python syntax check for `validate-kv-cache-reuse.py`
- Local secret scan and Code Defender scan reported clean

The manifests are sanitized and do not include account IDs, IAM ARNs, subnet IDs, security group IDs, private node IPs, or live cluster names.
